### PR TITLE
fix rectangle coords check when src/dst have the same size

### DIFF
--- a/raspi2fb.c
+++ b/raspi2fb.c
@@ -158,11 +158,11 @@ main(
         case 'y':
             copyRectY = atoi(optarg);
             break;
-            
+
         case 'r':
             copyRect = true;
             break;
-            
+
         case 'd':
 
             isDaemon = true;
@@ -237,7 +237,7 @@ main(
                 exit(EXIT_FAILURE);
             }
         }
-        
+
         if (daemon(0, 0) == -1)
         {
             fprintf(stderr, "Cannot daemonize\n");
@@ -368,7 +368,7 @@ main(
 
         exitAndRemovePidFile(EXIT_FAILURE, pfh);
     }
-    
+
     if (copyRectY > (info.height - vinfo.yres))
     {
         char s[80];
@@ -379,7 +379,6 @@ main(
 
         exitAndRemovePidFile(EXIT_FAILURE, pfh);
     }
-    
 
     //---------------------------------------------------------------------
 
@@ -405,7 +404,7 @@ main(
 
     DISPMANX_RESOURCE_HANDLE_T resourceHandle;
     VC_RECT_T rect;
-    
+
     if (copyRect) {
         resourceHandle = vc_dispmanx_resource_create(VC_IMAGE_RGB565,
                                                      info.width,
@@ -419,17 +418,16 @@ main(
                                                      &image_ptr);
         vc_dispmanx_rect_set(&rect, 0, 0, vinfo.xres, vinfo.yres);
     }
-        
+
     //---------------------------------------------------------------------
 
     uint32_t len = copyRect ? (info.width * info.height * 2) : finfo.smem_len;
-    
+
     uint16_t *backCopyP = malloc(len);
     uint16_t *frontCopyP = malloc(len);
 
     uint32_t line_len = copyRect ? (info.width * 2) : finfo.line_length;
-    
-    
+
     if ((backCopyP == NULL) || (frontCopyP == NULL))
     {
         perrorLog(isDaemon, program, "cannot allocate offscreen buffers");
@@ -476,7 +474,7 @@ main(
 
     // pixels = count of destination framebuffer pixels
     uint32_t pixels = vinfo.xres * vinfo.yres;
-    
+
     while (run)
     {
         gettimeofday(&start_time, NULL);
@@ -497,7 +495,7 @@ main(
             {
                 uint16_t* rowIter = frontCopyP + ((pixel_y + copyRectY) * info.width) + copyRectX;
                 uint16_t* fbIter = fbp + (pixel_y * vinfo.xres);
-                
+
                 for (uint16_t pixel_x = 0 ; pixel_x < vinfo.xres ; pixel_x++)
                 {
                     *(fbIter++) = *(rowIter++);
@@ -510,7 +508,7 @@ main(
             uint16_t *fbIter = fbp;
             uint16_t *frontCopyIter = frontCopyP;
             uint16_t *backCopyIter = backCopyP;
-            
+
             uint32_t pixel;
             for (pixel = 0 ; pixel < pixels ; pixel++)
             {
@@ -518,12 +516,12 @@ main(
                 {
                     *fbIter = *frontCopyIter;
                 }
-                
+
                 ++frontCopyIter;
                 ++backCopyIter;
                 ++fbIter;
             }
-            
+
             uint16_t *tmp = backCopyP;
             backCopyP = frontCopyP;
             frontCopyP = tmp;
@@ -576,4 +574,3 @@ main(
 
     return 0 ;
 }
-

--- a/raspi2fb.c
+++ b/raspi2fb.c
@@ -358,10 +358,10 @@ main(
     }
 
 
-    if (copyRectX >= (info.width - vinfo.xres))
+    if (copyRectX > (info.width - vinfo.xres))
     {
         char s[80];
-        snprintf(s, 80, "rectx must be between 0 and %d for the configured framebuffers", (info.width - vinfo.xres) - 1);
+        snprintf(s, 80, "rectx must be between 0 and %d for the configured framebuffers", info.width - vinfo.xres);
         perrorLog(isDaemon,
                   program,
                   s);
@@ -369,10 +369,10 @@ main(
         exitAndRemovePidFile(EXIT_FAILURE, pfh);
     }
     
-    if (copyRectY >= (info.height - vinfo.yres))
+    if (copyRectY > (info.height - vinfo.yres))
     {
         char s[80];
-        snprintf(s, 80, "recty must be between 0 and %d for the configured framebuffers", (info.height - vinfo.yres) - 1);
+        snprintf(s, 80, "recty must be between 0 and %d for the configured framebuffers", info.height - vinfo.yres);
         perrorLog(isDaemon,
                   program,
                   s);


### PR DESCRIPTION
Hi, first of all thanks for this software, it is really useful.

While setting up my Adafruit PiTFT 2.8" again after a long time of not using it I noticed that `raspi2fb` does not work anymore for me with the following error:

    rectx must be between 0 and -1 for the configured framebuffers

I went to debug and realised that the recent "copyrect" functionality did not properly account for the case of same src/dst sizes, thus mistakenly giving the above error. This PR fixes the problem.

My `config.txt` file where I set the HDMI mode to `320x240` and the PiTFT which is also `320x240` is:
```
# PiTFT 2.8
dtoverlay=pitft28-resistive,speed=64000000,fps=30
disable_overscan=1
hdmi_force_hotplug=1
hdmi_group=2
hdmi_mode=87
hdmi_cvt=320 240 60 1 0 0 0
```

I also fixed spurious blank spaces and lines in the codebase :)
